### PR TITLE
fix/improvement `performance` check for old browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ export default class ClapprStats extends ContainerPlugin {
   get _playbackName() {return this.container.playback.name}
   get _playbackType() {return this.container.getPlaybackType()}
   _now() {
-    const hasPerformanceSupport = performance && typeof(performance.now) === 'function'
-    return (hasPerformanceSupport)?performance.now():new Date()
+    const hasPerformanceSupport = window.performance && typeof(window.performance.now) === 'function'
+    return (hasPerformanceSupport)?window.performance.now():new Date()
   }
   _inc(counter) {this._metrics.counters[counter] += 1}
   _timerHasStarted(timer){return this[`_start${timer}`] !== undefined}


### PR DESCRIPTION
**Mobile Safari Version:** 8.0
**iOS Version:** 8.1.1

**Fix for:**
ReferenceError
Can't find variable: performance

I'm pretty sure this issue happen for all other older browsers. Ex: internet explorer, some old android chrome.

As this issue is critical, since the javascript stop executing I think it's important to fix it, otherwise it wouldn't make sense to have the **new Date()**